### PR TITLE
Improve ci & add some neat scripts 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [16]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
 
 jobs:
   ci:
@@ -20,16 +18,16 @@ jobs:
         node: [14]
 
     steps:
-      - name: Checkout 🛎
+      - name: Checkout
         uses: actions/checkout@master
 
-      - name: Setup node env 🏗
+      - name: Setup node env
         uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
 
-      - name: Cache node_modules 📦
+      - name: Cache node_modules
         uses: actions/cache@v2.1.4
         with:
           path: ~/.npm
@@ -37,11 +35,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install dependencies 👨🏻‍💻
+      - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
 
-      - name: Run linter 👀
+      - name: Run linter
         run: npm run lint
 
-      - name: Run tests 🧪
+      - name: Run tests
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Run build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "nuxt",
     "build": "nuxt build",
+    "analyze": "nuxt build --analyze",
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:prettier": "prettier --check .",
     "lint": "npm run lint:js && npm run lint:style && npm run lint:prettier",
     "lintfix": "prettier --write --list-different . && npm run lint:js -- --fix && npm run lint:style -- --fix",
-    "test": "jest"
+    "test": "jest",
+    "lint-test": "npm run lint && npm run test",
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lintfix": "prettier --write --list-different . && npm run lint:js -- --fix && npm run lint:style -- --fix",
     "test": "jest",
     "lint-test": "npm run lint && npm run test",
+    "new": "cross-env HYGEN_TMPLS=generators hygen new"
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",


### PR DESCRIPTION
- Switched node version for CI from 14 to 16;
- Now CI also runs build;
- Now there is a command `npm run lint-test` that runs linter, tests and build - useful for checking code before pushing;
- Added `npm run analyze` command - it helps to analyze the bundle.
- Added `npm run new` command that generates files with Hygen.
