### PR TITLE
Use modern build by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "nuxt build",
+    "build": "nuxt build --modern",
     "analyze": "nuxt build --analyze",
     "start": "nuxt start",
     "generate": "nuxt generate",


### PR DESCRIPTION
Use modern build option — it builds an additional bundle for modern browsers with fewer polyfills. 
Look for details in [nuxt's docs](https://nuxtjs.org/docs/configuration-glossary/configuration-modern/).