### PR TITLE
Restrict whole lodash import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,10 @@ module.exports = {
         patterns: ['../*', 'lodash.*'],
         paths: [
           {
+            name: 'lodash',
+            message: "Please import methods directly (like 'lodash/debounce').",
+          },
+          {
             name: '@vue/test-utils',
             importNames: ['mount'],
             message: 'Please use shallowMount instead.',


### PR DESCRIPTION
Force direct lodash method import to avoid unnecessary bundle bloating.